### PR TITLE
Revert "Fix GISPS calculation after recovery by resetting m_range_searched in set_block()"

### DIFF
--- a/src/cpu/src/cpu/worker_prime.cpp
+++ b/src/cpu/src/cpu/worker_prime.cpp
@@ -174,9 +174,6 @@ void Worker_prime::set_block(LLP::CBlock block, std::uint32_t nbits, Worker::Blo
 			//clear out any old chains from the last block
 			m_segmented_sieve->clear_chains();
 
-			// Reset statistics for new block
-			reset_statistics();
-
 			// Signal new work is available
 			m_stop = true;
 			m_new_work = true;
@@ -262,9 +259,6 @@ void Worker_prime::set_block(std::shared_ptr<WorkPackage> work_package, Worker::
 			//m_logger->debug("starting nonce: {}", m_nonce);
 			//clear out any old chains from the last block
 			m_segmented_sieve->clear_chains();
-
-			// Reset statistics for new block
-			reset_statistics();
 
 			// Signal new work is available
 			m_stop = true;
@@ -625,11 +619,6 @@ void Worker_prime::update_statistics(stats::Collector& stats_collector)
 
 	m_primes = 0;
 	m_chains = 0;
-}
-
-void Worker_prime::reset_statistics()
-{
-	m_range_searched = 0;
 }
 
 void Worker_prime::fermat_performance_test()

--- a/src/gpu/inc/gpu/worker_prime.hpp
+++ b/src/gpu/inc/gpu/worker_prime.hpp
@@ -42,8 +42,6 @@ public:
 
 private:
 
-    void reset_statistics();
-
     void run();
     double getDifficulty(uint1k p);
     double getNetworkDifficulty();

--- a/src/gpu/src/gpu/worker_prime.cpp
+++ b/src/gpu/src/gpu/worker_prime.cpp
@@ -109,9 +109,6 @@ void Worker_prime::set_block(LLP::CBlock block, std::uint32_t nbits, Worker::Blo
 		//clear out any old chains from the last block
 		m_segmented_sieve->clear_chains();
 
-		// Reset statistics for new block
-		reset_statistics();
-
 		// Signal new work is available
 		m_stop = true;
 		m_new_work = true;
@@ -180,9 +177,6 @@ void Worker_prime::set_block(std::shared_ptr<WorkPackage> work_package, Worker::
 		//m_logger->debug("starting nonce: {}", m_nonce);
 		//clear out any old chains from the last block
 		m_segmented_sieve->clear_chains();
-
-		// Reset statistics for new block
-		reset_statistics();
 
 		// Signal new work is available
 		m_stop = true;
@@ -425,11 +419,6 @@ void Worker_prime::update_statistics(stats::Collector& stats_collector)
 
 	m_primes = 0;
 	m_chains = 0;
-}
-
-void Worker_prime::reset_statistics()
-{
-	m_range_searched = 0;
 }
 
 


### PR DESCRIPTION
Reverts NamecoinGithub/NexusMiner#344