### PR TITLE
Revert PR #521 "Remove vOffsets from wire protocol: enforce 216-byte SUBMIT_BLOCK payload for all channels"

### DIFF
--- a/src/LLP/include/stateless_block_utility.hpp
+++ b/src/LLP/include/stateless_block_utility.hpp
@@ -19,13 +19,9 @@
  *   encode/decode logic is duplicated here.
  *
  * Encode (Miner -> Node)
- *   encode_submit() delegates block serialization to
- *   MiningTemplateInterface::prepare_block_submission(), then optionally signs
- *   with Disposable Falcon and frames with PacketBuilder.
- *
- *   Wire payload for ALL channels (Prime and Hash) is exactly BLOCK_BODY_SIZE
- *   (216 bytes).  vOffsets are NEVER transmitted; the node derives them from
- *   the nonce via GetOffsets(GetPrime(), vOffsets).
+ *   encode_submit() delegates block serialization (including Prime-channel
+ *   vOffsets) to MiningTemplateInterface::prepare_block_submission(), then
+ *   optionally signs with Disposable Falcon and frames with PacketBuilder.
  *
  * Namespace separation (canonical vs diagnostic):
  *   Canonical inputs  -- block.nHeight, block.nBits, block.nChannel,
@@ -171,13 +167,9 @@ public:
     /**
      * @brief Pre-check and wire-encode a solved block for submission.
      *
-     * Block serialization is delegated to
+     * Block serialization (including Prime-channel vOffsets) is delegated to
      * tmpl_iface.prepare_block_submission() -- no serialization logic is
      * duplicated here.
-     *
-     * Wire payload for ALL channels (Prime and Hash) is exactly BLOCK_BODY_SIZE
-     * (216 bytes).  vOffsets are NEVER transmitted on the wire; the node derives
-     * them from the nonce via GetOffsets(GetPrime(), vOffsets).
      *
      * Pre-check sequence (canonical gates, in order):
      *  1. Nonce sanity:     solved_block.nNonce != 0
@@ -185,13 +177,15 @@ public:
      *  3. Height validity:  solved_block.nHeight > 0
      *  4. Staleness (warn, do not block -- node is authoritative)
      *  5. Tip-moved  (warn, do not block)
-     *  6. MiningTemplateInterface::prepare_block_submission(merkle_root, nNonce)
+     *  6. MiningTemplateInterface::prepare_block_submission(merkle_root, nNonce, vOffsets)
      *  7. Falcon sign: if falcon != nullptr, sign serialized block bytes and append.
      *  8. PacketBuilder::build(lane, SUBMIT_BLOCK, payload).
      *
      * @param tmpl_iface    MiningTemplateInterface that owns the active template.
      *                      Must have a valid template (has_valid_template() == true).
      * @param solved_block  Block header with nNonce filled by the worker.
+     * @param vOffsets      Prime chain offsets from ValidatePrimeCandidate()
+     *                      (empty for Hash channel).
      * @param falcon        Disposable Falcon wrapper; nullptr = skip signing.
      * @param lane          ProtocolLane::STATELESS -> opcode 0xD001,
      *                      ProtocolLane::LEGACY    -> opcode 0x01.
@@ -207,6 +201,7 @@ public:
      */
      static SubmitResult encode_submit(MiningTemplateInterface& tmpl_iface,
                                        const ::LLP::CBlock& solved_block,
+                                       const std::vector<uint8_t>& vOffsets,
                                        FalconSignatureWrapper* falcon,
                                        ProtocolLane lane,
                                        const HeightTracker::Snapshot& ht,
@@ -220,15 +215,15 @@ public:
     /**
      * @brief Build a SubmitBlockPayloadInfo from runtime submit data.
      *
-     * This helper computes expected sizes from real inputs.  Both Hash and
-     * Prime submissions are fixed-size: wire payload is always exactly
-     * BLOCK_BODY_SIZE (216 bytes).  offset_bytes_count is always 0 because
-     * vOffsets are never transmitted on the wire — the node derives them from
-     * the nonce via GetOffsets(GetPrime(), vOffsets).
+     * This helper computes expected sizes from real inputs rather than
+     * assuming a universal fixed Tritium payload size.  Hash submissions
+     * are fixed-size; Prime submissions are variable because
+     * prepare_block_submission() appends vOffsets.
      *
      * @param channel          1 = Prime, 2 = Hash
      * @param block_data_size  Total serialized block bytes returned by
-     *                         prepare_block_submission() (always 216).
+     *                         prepare_block_submission() (includes vOffsets
+     *                         for Prime).  For Hash this is always 216.
      * @param signature_size   Actual Falcon signature length (0 when unsigned).
      * @return Populated SubmitBlockPayloadInfo with all size fields.
      */

--- a/src/LLP/stateless_block_utility.cpp
+++ b/src/LLP/stateless_block_utility.cpp
@@ -124,6 +124,7 @@ DecodedTemplate StatelessBlockUtility::decode_template(
 SubmitResult StatelessBlockUtility::encode_submit(
     MiningTemplateInterface& tmpl_iface,
     const ::LLP::CBlock& solved_block,
+    const std::vector<uint8_t>& vOffsets,
     FalconSignatureWrapper* falcon,
     ProtocolLane lane,
     const HeightTracker::Snapshot& ht,
@@ -196,13 +197,11 @@ SubmitResult StatelessBlockUtility::encode_submit(
     }
 
     // ── Pre-check 7: Delegate serialization to MiningTemplateInterface ────────
-    // prepare_block_submission(merkle_root, nonce) handles Tritium format and
-    // submit-audit logging.  Wire payload is always exactly BLOCK_BODY_SIZE
-    // (216 bytes) for ALL channels — vOffsets are never transmitted on the wire;
-    // the node derives them from the nonce via GetOffsets(GetPrime(), vOffsets).
+    // prepare_block_submission(merkle_root, nonce, vOffsets) handles Tritium
+    // format, submit-audit logging, and Prime-channel vOffsets appending.
     auto merkle_bytes = solved_block.hashMerkleRoot.GetBytes();
     auto block_bytes = tmpl_iface.prepare_block_submission(
-        merkle_bytes, solved_block.nNonce);
+        merkle_bytes, solved_block.nNonce, vOffsets);
 
     if (block_bytes.empty()) {
         result.rejection_reason =
@@ -257,8 +256,8 @@ SubmitResult StatelessBlockUtility::encode_submit(
                           "signed: block({})+ts(8)+siglen(2)+sig({}) = {} bytes",
                           block_bytes.size(), sig_len, plaintext.size());
     } else {
-        // No signing -- payload is just the serialized block bytes (216 bytes
-        // for ALL channels; vOffsets are never appended to the wire payload).
+        // No signing -- payload is just the serialized block bytes (+ any vOffsets
+        // already appended by prepare_block_submission for Prime channel)
         plaintext = std::move(block_bytes);
         if (logger)
             logger->debug("[StatelessBlockUtility::encode_submit] "
@@ -290,9 +289,11 @@ ChaCha20Wrapper::SubmitBlockPayloadInfo StatelessBlockUtility::compute_submit_pa
     ChaCha20Wrapper::SubmitBlockPayloadInfo info;
     info.channel            = channel;
     info.base_block_size    = BLOCK_BODY_SIZE;  // 216 for Tritium
-    // vOffsets are never transmitted on the wire (node derives from nonce).
-    // offset_bytes_count is always 0 for both Prime and Hash channels.
-    info.offset_bytes_count = 0;
+    // For Prime, offset bytes = total block_data_size - base 216-byte block body.
+    // For Hash, block_data_size should equal 216, so offset_bytes_count = 0.
+    info.offset_bytes_count = (block_data_size > BLOCK_BODY_SIZE)
+                                ? (block_data_size - BLOCK_BODY_SIZE)
+                                : 0;
     info.timestamp_size     = 8;
     info.sig_len_field_size = 2;
     info.signature_size     = signature_size;

--- a/src/protocol/e2e_block_submission_test.cpp
+++ b/src/protocol/e2e_block_submission_test.cpp
@@ -7,22 +7,22 @@
  *
  * Tests (acceptance criteria):
  *  1.  Hash channel: encode_submit → ChaCha20 encrypt → decrypt round-trip
- *  2.  Prime channel: encode_submit → ChaCha20 round-trip (no vOffsets on wire)
+ *  2.  Prime channel: encode_submit with vOffsets → ChaCha20 round-trip
  *  3.  Decrypted Hash payload is exactly BLOCK_BODY_SIZE (216) bytes
- *  4.  Decrypted Prime payload = BLOCK_BODY_SIZE (216 bytes, same as Hash)
- *  5.  Prime wire payload is exactly 216 bytes (vOffsets NOT transmitted)
+ *  4.  Decrypted Prime payload = BLOCK_BODY_SIZE + vOffsets.size()
+ *  5.  vOffsets bytes survive the full pipeline (byte-exact verification)
  *  6.  KDF session key is deterministic (same genesis → same key)
  *  7.  Wrong session key → ChaCha20 decrypt fails
  *  8.  AAD mismatch (non-empty vs empty) → decrypt fails
  *  9.  STATELESS lane: final SUBMIT_BLOCK packet has correct structure
  * 10.  LEGACY lane: final SUBMIT_BLOCK packet has correct structure
- * 11.  prepare_block_submission() always returns exactly 216 bytes (vOffsets ignored)
+ * 11.  Prime-channel vOffsets flow through prepare_block_submission()
  * 12.  Empty vOffsets for Hash channel (no extra bytes appended)
  * 13.  SubmitBlockPayloadInfo: Hash Falcon-1024 fixed-size (pt=1803, enc=1831)
- * 14.  SubmitBlockPayloadInfo: Prime always 216 bytes (offset_bytes_count=0)
- * 15.  SubmitBlockPayloadInfo: Prime == Hash (offset_bytes_count always 0)
+ * 14.  SubmitBlockPayloadInfo: Prime + 10 offsets (pt=1813, enc=1841)
+ * 15.  SubmitBlockPayloadInfo: Prime != Hash when offsets present
  * 16.  E2E: Hash unsigned payload_info + encrypt size correct
- * 17.  E2E: Prime full pipeline size correct (216 bytes, no vOffsets)
+ * 17.  E2E: Prime with vOffsets full pipeline size correct
  */
 
 #include "include/stateless_block_utility.hpp"
@@ -194,7 +194,7 @@ static void test_e2e_hash_channel_round_trip() {
 
     // Step 1: encode_submit
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     if (!submit.valid) {
         print_result("E2E Hash: encode_submit succeeds", false);
         return;
@@ -226,25 +226,23 @@ static void test_e2e_hash_channel_round_trip() {
     print_result("E2E Hash: encode_submit → ChaCha20 encrypt → decrypt round-trip", ok);
 }
 
-// Test 2: Prime channel encode_submit → ChaCha20 round-trip (no vOffsets on wire)
+// Test 2: Prime channel with vOffsets full pipeline
 static void test_e2e_prime_channel_voffsets_round_trip() {
     auto mti  = make_loaded_mti(1);  // Prime channel
     auto blk  = make_solved_block(1);
     auto snap = make_snapshot();
+    std::vector<uint8_t> vOffsets = {0x02, 0x04, 0x00, 0x10, 0x20, 0x30, 0x40};
 
-    // Step 1: encode_submit (no vOffsets -- they are never transmitted on the wire)
+    // Step 1: encode_submit with vOffsets
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, vOffsets, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     if (!submit.valid) {
-        print_result("E2E Prime: encode_submit succeeds (no vOffsets on wire)", false);
+        print_result("E2E Prime: encode_submit with vOffsets succeeds", false);
         return;
     }
 
     // Step 2: strip wire header
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
-
-    // Verify payload is exactly 216 bytes (no vOffsets appended)
-    bool size_ok = (plaintext.size() == StatelessBlockUtility::BLOCK_BODY_SIZE);
 
     // Step 3: encrypt (miner side)
     std::vector<uint8_t> genesis(32, 0xAB);
@@ -255,8 +253,8 @@ static void test_e2e_prime_channel_voffsets_round_trip() {
 
     // Step 4: decrypt (node side)
     auto dec = wrapper.decrypt(enc.data, session_key, enc_nonce, AAD_BLOCK_SUBMISSION);
-    bool ok = size_ok && dec.success && (dec.data == plaintext);
-    print_result("E2E Prime: encode_submit → ChaCha20 round-trip (no vOffsets on wire)", ok);
+    bool ok = dec.success && (dec.data == plaintext);
+    print_result("E2E Prime: encode_submit + vOffsets → ChaCha20 round-trip", ok);
 }
 
 // Test 3: Hash decrypted payload is exactly BLOCK_BODY_SIZE (216 bytes)
@@ -266,41 +264,38 @@ static void test_hash_payload_size() {
     auto snap = make_snapshot();
 
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
     bool ok = submit.valid && (plaintext.size() == StatelessBlockUtility::BLOCK_BODY_SIZE);
     print_result("E2E Hash: decrypted payload = 216 bytes (BLOCK_BODY_SIZE)", ok);
 }
 
-// Test 4: Prime decrypted payload = BLOCK_BODY_SIZE (216 bytes, same as Hash)
+// Test 4: Prime decrypted payload = BLOCK_BODY_SIZE + vOffsets.size()
 static void test_prime_payload_size() {
     auto mti  = make_loaded_mti(1);
     auto blk  = make_solved_block(1);
     auto snap = make_snapshot();
+    std::vector<uint8_t> vOffsets = {0x02, 0x04, 0x00, 0x10, 0x20, 0x30, 0x40};
 
-    // vOffsets are NOT transmitted; encode_submit takes no vOffsets parameter
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, vOffsets, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
     bool ok = submit.valid &&
-              (plaintext.size() == StatelessBlockUtility::BLOCK_BODY_SIZE);
-    print_result("E2E Prime: decrypted payload = 216 bytes (BLOCK_BODY_SIZE, no vOffsets)", ok);
+              (plaintext.size() == StatelessBlockUtility::BLOCK_BODY_SIZE + vOffsets.size());
+    print_result("E2E Prime: decrypted payload = 216 + vOffsets.size() bytes", ok);
 }
 
-// Test 5: Prime wire payload is exactly 216 bytes (vOffsets NOT transmitted)
+// Test 5: vOffsets bytes survive the full pipeline (byte-exact)
 static void test_voffsets_byte_exact() {
     auto mti  = make_loaded_mti(1);
     auto blk  = make_solved_block(1);
     auto snap = make_snapshot();
+    std::vector<uint8_t> vOffsets = {0x02, 0x04, 0x00, 0x10, 0x20, 0x30, 0x40};
 
-    // encode_submit (no vOffsets parameter -- they are never on the wire)
+    // encode_submit
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, vOffsets, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
-
-    // Prime payload must be exactly 216 bytes (same as Hash)
-    bool size_ok = submit.valid &&
-                   (plaintext.size() == StatelessBlockUtility::BLOCK_BODY_SIZE);
 
     // ChaCha20 round-trip
     std::vector<uint8_t> genesis(32, 0xAB);
@@ -310,8 +305,16 @@ static void test_voffsets_byte_exact() {
     auto enc = wrapper.encrypt(plaintext, session_key, enc_nonce, AAD_BLOCK_SUBMISSION);
     auto dec = wrapper.decrypt(enc.data, session_key, enc_nonce, AAD_BLOCK_SUBMISSION);
 
-    bool ok = size_ok && dec.success && (dec.data == plaintext);
-    print_result("E2E Prime: wire payload = 216 bytes (vOffsets NOT transmitted)", ok);
+    // Verify vOffsets at tail of decrypted payload
+    bool ok = false;
+    if (dec.success && dec.data.size() >= StatelessBlockUtility::BLOCK_BODY_SIZE + vOffsets.size()) {
+        size_t offset_start = StatelessBlockUtility::BLOCK_BODY_SIZE;
+        std::vector<uint8_t> recovered(
+            dec.data.begin() + offset_start,
+            dec.data.begin() + offset_start + vOffsets.size());
+        ok = (recovered == vOffsets);
+    }
+    print_result("E2E: vOffsets bytes survive full pipeline (byte-exact match)", ok);
 }
 
 // Test 6: KDF determinism — same genesis → same session key
@@ -330,7 +333,7 @@ static void test_wrong_key_decrypt_fails() {
     auto snap = make_snapshot();
 
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
 
     std::vector<uint8_t> genesis(32, 0xAB);
@@ -353,7 +356,7 @@ static void test_aad_mismatch_fails() {
     auto snap = make_snapshot();
 
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
 
     std::vector<uint8_t> genesis(32, 0xAB);
@@ -377,7 +380,7 @@ static void test_stateless_submit_packet_structure() {
     auto snap = make_snapshot();
 
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
 
     std::vector<uint8_t> genesis(32, 0xAB);
@@ -412,7 +415,7 @@ static void test_legacy_submit_packet_structure() {
     auto snap = make_snapshot();
 
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::LEGACY, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::LEGACY, snap, nullptr);
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::LEGACY);
 
     std::vector<uint8_t> genesis(32, 0xAB);
@@ -437,7 +440,7 @@ static void test_legacy_submit_packet_structure() {
     print_result("E2E LEGACY: SUBMIT_BLOCK packet = [0x01][len][nonce(12)][ct+tag]", ok);
 }
 
-// Test 11: prepare_block_submission() always returns exactly 216 bytes (vOffsets not appended)
+// Test 11: vOffsets flow through prepare_block_submission (Prime channel)
 static void test_voffsets_flow_prepare_block_submission() {
     MiningTemplateInterface mti_prime(1, 0);
     auto payload = make_template_payload(6000000, 2000000, DEFAULT_DIFFICULTY,
@@ -446,19 +449,33 @@ static void test_voffsets_flow_prepare_block_submission() {
 
     const auto* tmpl = mti_prime.get_current_template();
     if (!tmpl) {
-        print_result("prepare_block_submission: template loaded", false);
+        print_result("vOffsets flow: template loaded", false);
         return;
     }
 
-    // prepare_block_submission (no vOffsets parameter -- vOffsets are never transmitted)
-    auto result = mti_prime.prepare_block_submission(
-        tmpl->block.hashMerkleRoot.GetBytes(), 0xDEADBEEFCAFEBABEULL);
+    std::vector<uint8_t> vOffsets = {0x02, 0x04, 0x00, 0x10, 0x20, 0x30, 0x40};
 
-    // Must always be exactly BLOCK_BODY_SIZE (216 bytes) for Prime channel
-    bool size_ok = (result.size() == StatelessBlockUtility::BLOCK_BODY_SIZE);
+    // prepare_block_submission with vOffsets (Prime)
+    auto with_offsets = mti_prime.prepare_block_submission(
+        tmpl->block.hashMerkleRoot.GetBytes(), 0xDEADBEEFCAFEBABEULL, vOffsets);
 
-    print_result("prepare_block_submission(): Prime channel = 216 bytes (vOffsets not appended)",
-                 size_ok);
+    // prepare_block_submission without vOffsets
+    auto without_offsets = mti_prime.prepare_block_submission(
+        tmpl->block.hashMerkleRoot.GetBytes(), 0xDEADBEEFCAFEBABEULL, {});
+
+    // With vOffsets should be exactly vOffsets.size() bytes larger
+    bool size_ok = (with_offsets.size() == without_offsets.size() + vOffsets.size());
+
+    // Verify vOffsets appear at the tail
+    bool tail_ok = false;
+    if (with_offsets.size() >= vOffsets.size()) {
+        std::vector<uint8_t> tail(
+            with_offsets.end() - vOffsets.size(), with_offsets.end());
+        tail_ok = (tail == vOffsets);
+    }
+
+    print_result("vOffsets flow: prepare_block_submission() appends vOffsets "
+                 "(Prime channel, byte-exact at tail)", size_ok && tail_ok);
 }
 
 // Test 12: Hash channel prepare_block_submission with empty vOffsets
@@ -475,7 +492,7 @@ static void test_hash_no_voffsets_appended() {
     }
 
     auto result = mti_hash.prepare_block_submission(
-        tmpl->block.hashMerkleRoot.GetBytes(), 0xDEADBEEFCAFEBABEULL);
+        tmpl->block.hashMerkleRoot.GetBytes(), 0xDEADBEEFCAFEBABEULL, {});
 
     bool ok = (result.size() == StatelessBlockUtility::BLOCK_BODY_SIZE);
     print_result("Hash channel: prepare_block_submission() = 216 bytes (no vOffsets)", ok);
@@ -502,39 +519,39 @@ static void test_payload_info_hash_falcon1024() {
                  siglen_ok && sig_ok && plain_ok && enc_ok);
 }
 
-// ── Test 14: SubmitBlockPayloadInfo Prime always 216 bytes (offset_bytes_count=0) ──
-// Prime: offset_bytes_count=0, plaintext = 216 + 8 + 2 + 1577 = 1803, same as Hash
+// ── Test 14: SubmitBlockPayloadInfo Prime with 10 offset bytes ──────────────
+// Prime: plaintext = 216 + 10 + 8 + 2 + 1577 = 1813, encrypted = 1813 + 28 = 1841
 static void test_payload_info_prime_with_offsets() {
+    const size_t offset_count = 10;
     auto info = StatelessBlockUtility::compute_submit_payload_info(
-        /*channel=*/1, /*block_data_size=*/216,
+        /*channel=*/1, /*block_data_size=*/216 + offset_count,
         /*signature_size=*/FalconConstants::FALCON1024_SIG_CT_SIZE);
 
     bool channel_ok   = (info.channel == 1);
     bool base_ok      = (info.base_block_size == 216);
-    bool offset_ok    = (info.offset_bytes_count == 0);  // always 0 -- never transmitted
-    bool plain_ok     = (info.expected_plaintext_size() == 1803);  // same as Hash
-    bool enc_ok       = (info.expected_encrypted_size() == 1831);  // same as Hash
+    bool offset_ok    = (info.offset_bytes_count == offset_count);
+    bool plain_ok     = (info.expected_plaintext_size() == 1813);
+    bool enc_ok       = (info.expected_encrypted_size() == 1841);
 
-    print_result("PayloadInfo Prime F1024: offset_bytes_count=0, plaintext=1803 (same as Hash)",
+    print_result("PayloadInfo Prime F1024 (10 offsets): plaintext=1813, encrypted=1841",
                  channel_ok && base_ok && offset_ok && plain_ok && enc_ok);
 }
 
-// ── Test 15: Prime and Hash produce identical expected sizes ─────────────────
-// With offset_bytes_count always 0, Prime and Hash are identical on the wire.
+// ── Test 15: Prime variable-size is NOT Hash fixed-size ─────────────────────
+// Verifies that Hash and Prime with offsets produce different expected sizes.
 static void test_payload_info_prime_not_equal_hash() {
     auto hash_info = StatelessBlockUtility::compute_submit_payload_info(
         2, 216, FalconConstants::FALCON1024_SIG_CT_SIZE);
     auto prime_info = StatelessBlockUtility::compute_submit_payload_info(
-        1, 216, FalconConstants::FALCON1024_SIG_CT_SIZE);
+        1, 216 + 7, FalconConstants::FALCON1024_SIG_CT_SIZE);
 
-    // Both must produce identical sizes (vOffsets are never on the wire)
-    bool sizes_equal = (prime_info.expected_plaintext_size() ==
-                        hash_info.expected_plaintext_size());
-    bool offsets_zero = (prime_info.offset_bytes_count == 0) &&
-                        (hash_info.offset_bytes_count == 0);
+    bool sizes_differ = (prime_info.expected_plaintext_size() !=
+                         hash_info.expected_plaintext_size());
+    bool prime_larger  = (prime_info.expected_plaintext_size() ==
+                          hash_info.expected_plaintext_size() + 7);
 
-    print_result("PayloadInfo: Prime == Hash (offset_bytes_count=0 for both channels)",
-                 sizes_equal && offsets_zero);
+    print_result("PayloadInfo: Prime(7 offsets) != Hash, differs by offset count",
+                 sizes_differ && prime_larger);
 }
 
 // ── Test 16: E2E integration — encode_submit → compute_payload_info → ChaCha20 ──
@@ -546,7 +563,7 @@ static void test_e2e_payload_info_hash_unsigned() {
     auto snap = make_snapshot();
 
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
 
     // For unsigned submit, plaintext = block bytes only (216)
@@ -571,24 +588,23 @@ static void test_e2e_payload_info_hash_unsigned() {
                  actual_ok && enc_ok);
 }
 
-// ── Test 17: E2E integration — Prime full pipeline (always 216 bytes) ─────────
-// Exercises encode_submit → ChaCha20 → verify sizes for Prime channel
+// ── Test 17: E2E integration — Prime with vOffsets through full pipeline ─────
+// Exercises prepare_block_submission → encode_submit → ChaCha20 → verify sizes
 static void test_e2e_payload_info_prime_pipeline() {
     auto mti  = make_loaded_mti(1);  // Prime
     auto blk  = make_solved_block(1);
     auto snap = make_snapshot();
+    std::vector<uint8_t> vOffsets(10, 0x42);  // 10 offset bytes
 
-    // vOffsets are NOT transmitted; encode_submit takes no vOffsets parameter
     auto submit = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, vOffsets, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     if (!submit.valid) {
         print_result("E2E PayloadInfo Prime pipeline: encode_submit succeeds", false);
         return;
     }
 
     auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
-    // Prime plaintext must be exactly 216 bytes (same as Hash)
-    bool plain_ok = (plaintext.size() == StatelessBlockUtility::BLOCK_BODY_SIZE);
+    bool plain_ok = (plaintext.size() == StatelessBlockUtility::BLOCK_BODY_SIZE + vOffsets.size());
 
     // Encrypt
     std::vector<uint8_t> genesis(32, 0xAB);
@@ -601,9 +617,9 @@ static void test_e2e_payload_info_prime_pipeline() {
     auto dec = wrapper.decrypt(enc.data, session_key, enc_nonce, AAD_BLOCK_SUBMISSION);
     bool rt_ok = dec.success && (dec.data == plaintext);
 
-    // Verify payload info: offset_bytes_count is always 0
-    auto info = StatelessBlockUtility::compute_submit_payload_info(1, 216, 0);
-    bool info_ok = (info.offset_bytes_count == 0) && (info.channel == 1);
+    // Verify payload info matches
+    auto info = StatelessBlockUtility::compute_submit_payload_info(1, 216 + 10, 0);
+    bool info_ok = (info.offset_bytes_count == 10) && (info.channel == 1);
 
     // Final encrypted wire payload = nonce(12) + ciphertext(plaintext.size()) + tag(16)
     size_t expected_wire = 12 + plaintext.size() + 16;
@@ -612,9 +628,10 @@ static void test_e2e_payload_info_prime_pipeline() {
     wire_payload.insert(wire_payload.end(), enc.data.begin(), enc.data.end());
     bool wire_ok = (wire_payload.size() == expected_wire);
 
-    print_result("E2E PayloadInfo Prime: 216 bytes (no vOffsets), full pipeline size correct",
+    print_result("E2E PayloadInfo Prime (10 offsets): full pipeline size correct",
                  plain_ok && rt_ok && info_ok && wire_ok);
 }
+
 
 // ── Test 18: E2E via encrypt_submit_block_payload() — canonical wrapper path ─
 // Validates: encode_submit → compute_submit_payload_info → encrypt_submit_block_payload
@@ -631,7 +648,7 @@ static void test_e2e_encrypt_submit_block_payload() {
         auto snap = make_snapshot();
 
         auto submit = StatelessBlockUtility::encode_submit(
-            *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+            *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
         if (!submit.valid) {
             print_result("E2E encrypt_submit_block_payload: Hash encode_submit succeeds", false);
             return;
@@ -656,15 +673,15 @@ static void test_e2e_encrypt_submit_block_payload() {
                      enc.success && enc.data.size() == expected_size);
     }
 
-    // ── Case B: Prime channel (unsigned, no vOffsets on wire) ────────────────
+    // ── Case B: Prime channel with 10 vOffsets (unsigned) ────────────────
     {
         auto mti  = make_loaded_mti(1);   // Prime
         auto blk  = make_solved_block(1);
         auto snap = make_snapshot();
+        std::vector<uint8_t> vOffsets(10, 0x42);
 
-        // vOffsets are NOT transmitted; encode_submit takes no vOffsets parameter
         auto submit = StatelessBlockUtility::encode_submit(
-            *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+            *mti, blk, vOffsets, nullptr, ProtocolLane::STATELESS, snap, nullptr);
         if (!submit.valid) {
             print_result("E2E encrypt_submit_block_payload: Prime encode_submit succeeds", false);
             return;
@@ -672,16 +689,16 @@ static void test_e2e_encrypt_submit_block_payload() {
 
         auto plaintext = strip_wire_header(*submit.wire_bytes, ProtocolLane::STATELESS);
 
-        // Unsigned Prime: plaintext = block(216) only (same as Hash)
+        // Unsigned Prime: plaintext = block(216) + offsets(10)
         auto info = StatelessBlockUtility::compute_submit_payload_info(
             1, plaintext.size(), 0);
 
         auto enc = wrapper.encrypt_submit_block_payload(plaintext, session_key, info);
-        print_result("E2E encrypt_submit_block_payload: Prime unsigned (216 bytes) — succeeds",
+        print_result("E2E encrypt_submit_block_payload: Prime+10-offsets unsigned — succeeds",
                      enc.success);
 
         const size_t expected_size = 12 + plaintext.size() + 16;
-        print_result("E2E encrypt_submit_block_payload: Prime — size = nonce+ct+tag",
+        print_result("E2E encrypt_submit_block_payload: Prime+10-offsets — size = nonce+ct+tag",
                      enc.success && enc.data.size() == expected_size);
 
         // Two calls must produce different outputs (fresh nonce each time)
@@ -725,7 +742,7 @@ int main() {
     test_stateless_submit_packet_structure();    // 9
     test_legacy_submit_packet_structure();       // 10
 
-    std::cout << "\n--- Wire Format Invariant (vOffsets not transmitted) ---\n";
+    std::cout << "\n--- vOffsets Flow ---\n";
     test_voffsets_flow_prepare_block_submission();// 11
     test_hash_no_voffsets_appended();            // 12
 

--- a/src/protocol/first_block_acceptance_test.cpp
+++ b/src/protocol/first_block_acceptance_test.cpp
@@ -413,6 +413,7 @@ HarnessResult run_first_block_acceptance_harness(const HarnessOptions& options)
     auto submit_result = StatelessBlockUtility::encode_submit(
         template_interface,
         solved_block,
+        {},
         nullptr,
         ProtocolLane::STATELESS,
         HeightTracker::Snapshot{},
@@ -430,7 +431,7 @@ HarnessResult run_first_block_acceptance_harness(const HarnessOptions& options)
     result.artifacts.submitted_payload_height = extract_serialized_block_height(plaintext_submit);
 
     auto expected_block_submission = template_interface.prepare_block_submission(
-        current_template->block.hashMerkleRoot.GetBytes(), ACCEPTANCE_NONCE);
+        current_template->block.hashMerkleRoot.GetBytes(), ACCEPTANCE_NONCE, {});
     result.artifacts.submit_validation_matches_template =
         (plaintext_submit == expected_block_submission);
     if (!result.artifacts.submit_validation_matches_template) {

--- a/src/protocol/inc/protocol/mining_template_interface.hpp
+++ b/src/protocol/inc/protocol/mining_template_interface.hpp
@@ -431,7 +431,22 @@ public:
     std::vector<uint8_t> prepare_block_submission(const std::vector<uint8_t>& merkle_root,
                                                    uint64_t nonce);
 
-
+    /**
+     * @brief Prepare block for submission, appending Prime channel vOffsets
+     *
+     * For the Prime channel (nChannel == 1), the Cunningham-chain offsets computed
+     * by ValidatePrimeCandidate() must be appended to the serialized block bytes so
+     * the node can verify the prime cluster. For the Hash channel, vOffsets is ignored.
+     *
+     * @param merkle_root Block's merkle root
+     * @param nonce Block's nonce value
+     * @param vOffsets Prime chain offsets (empty for Hash channel)
+     * @return Submission payload bytes (block bytes + vOffsets for Prime), empty if invalid
+     */
+    std::vector<uint8_t> prepare_block_submission(const std::vector<uint8_t>& merkle_root,
+                                                   uint64_t nonce,
+                                                   const std::vector<uint8_t>& vOffsets);
+    
     // =========================================================================
     // Session Management (FALCON Tunnel Integration)
     // =========================================================================

--- a/src/protocol/src/protocol/mining_template_interface.cpp
+++ b/src/protocol/src/protocol/mining_template_interface.cpp
@@ -638,6 +638,27 @@ std::vector<uint8_t> MiningTemplateInterface::prepare_block_submission(
     return payload;
 }
 
+std::vector<uint8_t> MiningTemplateInterface::prepare_block_submission(
+    const std::vector<uint8_t>& merkle_root,
+    uint64_t nonce,
+    const std::vector<uint8_t>& vOffsets)
+{
+    // Delegate the block serialization to the base overload
+    auto payload = prepare_block_submission(merkle_root, nonce);
+    if (payload.empty())
+        return payload;
+
+    // For Prime channel, append Cunningham-chain offsets so the node can verify
+    // the prime cluster via GetPrimeDifficulty() / GetOffsets().
+    // Hash channel vOffsets are always empty — no-op.
+    if (!vOffsets.empty() && m_channel == 1) {
+        payload.insert(payload.end(), vOffsets.begin(), vOffsets.end());
+        m_logger->debug("[TemplateInterface] Appended {} vOffset bytes for Prime channel",
+                        vOffsets.size());
+    }
+
+    return payload;
+}
 
 void MiningTemplateInterface::set_session_id(uint32_t session_id)
 {

--- a/src/protocol/src/protocol/solo.cpp
+++ b/src/protocol/src/protocol/solo.cpp
@@ -1323,12 +1323,14 @@ network::Shared_payload Solo::submit_block(std::vector<std::uint8_t> const& bloc
     m_last_submitted_height    = tmpl->block.nHeight;
     m_last_submitted_channel   = tmpl->block.nChannel;
 
-    // block_data is always exactly BLOCK_BODY_SIZE (216 bytes) for all channels.
-    // vOffsets are never transmitted on the wire; the node derives them from the
-    // nonce via GetOffsets(GetPrime(), vOffsets).
+    // Extract Prime channel vOffsets from block_data (bytes after 216-byte Tritium body).
+    // For Hash channel block_data is exactly 216 bytes so this is always empty.
+    std::vector<uint8_t> vOffsets;
+    if (block_data.size() > StatelessBlockUtility::BLOCK_BODY_SIZE)
+        vOffsets.assign(block_data.begin() + StatelessBlockUtility::BLOCK_BODY_SIZE, block_data.end());
 
     auto submit_result = StatelessBlockUtility::encode_submit(
-        *m_template_interface, block_to_submit,
+        *m_template_interface, block_to_submit, vOffsets,
         m_falcon_wrapper.get(), m_protocol_lane,
         submit_snapshot, m_logger, submit_context);
 
@@ -1360,12 +1362,13 @@ network::Shared_payload Solo::submit_block(std::vector<std::uint8_t> const& bloc
                          std::string(is_channel_height(submit_snapshot.channel_tip_height) ? "true" : "false"));
 
     // ── Channel-aware payload diagnostics ────────────────────────────────────
-    // Wire payload is always BLOCK_BODY_SIZE (216 bytes) for all channels.
-    // vOffsets are never transmitted; offset_bytes_count is always 0.
+    // Compute payload metadata from live data — offset_bytes_count is derived
+    // from real block_data, not defaulted to 0.
+    const size_t live_offset_bytes = vOffsets.size();
     // Signature size: in the signed path, plaintext includes
-    // block + timestamp(8) + sig_len(2) + signature.
-    // If unsigned (no Falcon), signature_size = 0 and plaintext = block only.
-    constexpr size_t block_plus_offsets = StatelessBlockUtility::BLOCK_BODY_SIZE;
+    // block + offsets + timestamp(8) + sig_len(2) + signature.
+    // If unsigned (no Falcon), signature_size = 0 and plaintext = block + offsets only.
+    const size_t block_plus_offsets = StatelessBlockUtility::BLOCK_BODY_SIZE + live_offset_bytes;
     // Minimum signed overhead = timestamp(8) + sig_len_field(2) = 10 bytes
     constexpr size_t MIN_SIGNED_OVERHEAD = 8 + 2;
     const size_t sig_size = (plaintextPayload.size() > block_plus_offsets + MIN_SIGNED_OVERHEAD)
@@ -1380,6 +1383,7 @@ network::Shared_payload Solo::submit_block(std::vector<std::uint8_t> const& bloc
                    payload_info.channel,
                    payload_info.channel == 1 ? "Prime" : "Hash");
     m_logger->info("[Solo Submit]   base_block_size    = {} bytes", payload_info.base_block_size);
+    m_logger->info("[Solo Submit]   offset_bytes_count = {} bytes", payload_info.offset_bytes_count);
     m_logger->info("[Solo Submit]   timestamp_size     = {} bytes", payload_info.timestamp_size);
     m_logger->info("[Solo Submit]   sig_len_field_size = {} bytes", payload_info.sig_len_field_size);
     m_logger->info("[Solo Submit]   signature_size     = {} bytes", payload_info.signature_size);

--- a/src/protocol/stateless_block_utility_test.cpp
+++ b/src/protocol/stateless_block_utility_test.cpp
@@ -12,12 +12,13 @@
  *  7.  encode_submit() with STATELESS lane produces opcode 0xD001
  *  8.  encode_submit() with LEGACY lane produces opcode 0x01
  *  9.  encode_submit() with falcon=nullptr produces unsigned submit
- *      (payload = block bytes only, 216 bytes for ALL channels)
+ *      (payload = block bytes + any vOffsets, no Falcon signature suffix)
  * 10.  decode_template() populates metadata fields from 12-byte prefix (BE)
  * 11.  decode_template() populates canonical block fields from 216-byte body
  * 12.  decode_template() sets channel_consistent correctly
  * 13.  encode_submit() informational staleness/tip-moved do not block submission
- * 14.  encode_submit() Prime and Hash produce identical wire payload size (216 bytes)
+ * 14.  encode_submit() with Prime-channel vOffsets produces larger payload than
+ *      Hash-channel (no vOffsets) submission
  */
 
 #include "include/stateless_block_utility.hpp"
@@ -226,7 +227,7 @@ static void test_encode_zero_nonce() {
     auto blk  = make_solved_block(2, 6000001, /*nNonce=*/0);
     auto snap = make_snapshot();
     auto result = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     print_result("encode_submit(): rejects zero nonce",
                  !result.valid && !result.rejection_reason.empty());
 }
@@ -237,7 +238,7 @@ static void test_encode_invalid_channel() {
     auto blk  = make_solved_block(/*channel=*/0, 6000001, 0xDEADBEEFULL);
     auto snap = make_snapshot();
     auto result = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     print_result("encode_submit(): rejects invalid channel (0)",
                  !result.valid && !result.rejection_reason.empty());
 }
@@ -248,7 +249,7 @@ static void test_encode_zero_height() {
     auto blk  = make_solved_block(2, /*height=*/0, 0xDEADBEEFULL);
     auto snap = make_snapshot();
     auto result = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     print_result("encode_submit(): rejects zero height",
                  !result.valid && !result.rejection_reason.empty());
 }
@@ -259,7 +260,7 @@ static void test_encode_stateless_opcode() {
     auto blk  = make_solved_block();
     auto snap = make_snapshot();
     auto result = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
 
     bool ok = false;
     if (result.valid && result.wire_bytes && result.wire_bytes->size() >= 2) {
@@ -275,7 +276,7 @@ static void test_encode_legacy_opcode() {
     auto blk  = make_solved_block();
     auto snap = make_snapshot();
     auto result = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::LEGACY, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::LEGACY, snap, nullptr);
 
     bool ok = false;
     if (result.valid && result.wire_bytes && !result.wire_bytes->empty()) {
@@ -294,7 +295,7 @@ static void test_encode_unsigned_submit() {
     auto snap = make_snapshot();
 
     auto result = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
 
     bool ok = false;
     if (result.valid && result.wire_bytes) {
@@ -363,7 +364,7 @@ static void test_encode_stale_does_not_block() {
     auto snap = ht.GetSnapshot();
 
     auto result = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
     print_result("encode_submit(): stale template is a warning, not a hard "
                  "rejection", result.valid);
 }
@@ -373,7 +374,7 @@ static void test_encode_rejects_submit_height_mismatch() {
     auto mti = make_loaded_mti();
     auto blk = make_solved_block(2, /*nHeight=*/6000002, 0xDEADBEEFCAFEBABEULL);
     auto result = StatelessBlockUtility::encode_submit(
-        *mti, blk, nullptr, ProtocolLane::STATELESS, make_snapshot(), nullptr,
+        *mti, blk, {}, nullptr, ProtocolLane::STATELESS, make_snapshot(), nullptr,
         make_submit_context(/*template_height=*/6000001, /*chain_height=*/6000000));
     print_result("encode_submit(): rejects authoritative submit-height mismatch",
                  !result.valid &&
@@ -381,7 +382,7 @@ static void test_encode_rejects_submit_height_mismatch() {
                  result.rejection_reason.find("submit_height=6000002") != std::string::npos);
 }
 
-// Test 15 -- Prime and Hash produce identical wire payload size (216 bytes, no vOffsets)
+// Test 15 -- Prime channel vOffsets produce larger payload than Hash channel
 static void test_encode_prime_voffsets_appended() {
     // Load a Prime-channel template (nChannel=1)
     MiningTemplateInterface mti_prime(1, 0);
@@ -399,17 +400,19 @@ static void test_encode_prime_voffsets_appended() {
     auto blk_hash  = make_solved_block(2, 6000001, 0xDEADBEEFCAFEBABEULL);
     auto snap = make_snapshot();
 
-    // vOffsets are NOT transmitted on the wire; encode_submit takes no vOffsets parameter
-    auto prime_result = StatelessBlockUtility::encode_submit(
-        mti_prime, blk_prime, nullptr, ProtocolLane::STATELESS, snap, nullptr);
-    auto hash_result  = StatelessBlockUtility::encode_submit(
-        mti_hash, blk_hash, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+    // Canonical Prime vOffsets shape: 6 single-byte offsets + 4-byte LE fraction.
+    std::vector<uint8_t> vOffsets = {0x02, 0x04, 0x06, 0x02, 0x04, 0x06, 0x10, 0x20, 0x30, 0x40};
 
-    // Prime and Hash wire payload must be identical size (both 216 bytes)
+    auto prime_result = StatelessBlockUtility::encode_submit(
+        mti_prime, blk_prime, vOffsets, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+    auto hash_result  = StatelessBlockUtility::encode_submit(
+        mti_hash, blk_hash, {}, nullptr, ProtocolLane::STATELESS, snap, nullptr);
+
     bool ok = prime_result.valid && hash_result.valid &&
-              prime_result.wire_bytes->size() == hash_result.wire_bytes->size();
-    print_result("encode_submit(): Prime and Hash produce identical wire payload (216 bytes)",
-                 ok);
+              prime_result.wire_bytes->size() ==
+                  hash_result.wire_bytes->size() + vOffsets.size();
+    print_result("encode_submit(): Prime vOffsets are appended to payload "
+                 "(Prime payload > Hash payload by vOffsets.size())", ok);
 }
 
 // Test 15 -- read_stateless_payload() + set_channel_height() does not trigger

--- a/src/worker/worker.hpp
+++ b/src/worker/worker.hpp
@@ -62,9 +62,10 @@ public:
 	uint32_t nBits = 0x7b032ed8;
 	uint64_t nNonce = 21155560019;
 
-	// vOffsets: Used for LOCAL difficulty screening only via ValidatePrimeCandidate().
-	// NOT transmitted to the node — node derives via GetOffsets(GetPrime(), vOffsets).
-	// CPU and GPU prime workers populate these before firing the submit callback.
+	// Prime channel offsets (Cunningham chain offsets from ValidatePrimeCandidate).
+	// Empty for Hash channel. CPU and GPU prime workers both populate these from
+	// the shared prime_validation.cpp pathway before firing the callback so that
+	// worker_manager can include them in prepare_block_submission().
 	std::vector<uint8_t> vOffsets;
 
 private:

--- a/src/worker_manager.cpp
+++ b/src/worker_manager.cpp
@@ -333,15 +333,18 @@ Worker_manager::Worker_manager(std::shared_ptr<asio::io_context> io_context, Con
 
                             // Prepare full block submission (216 or 220 bytes depending on format)
                             // This reconstructs the full block from the current template with the
-                            // mined merkle root and nonce. vOffsets are used locally for difficulty
-                            // screening only and are NOT transmitted on the wire.
+                            // mined merkle root and nonce
                             m_logger->info("[Worker_manager] Preparing full block submission");
                             m_logger->info("[Worker_manager]   Height: {}", block_data->nHeight);
                             m_logger->info("[Worker_manager]   Nonce:  0x{:016x}", block_data->nNonce);
+                            if (!block_data->vOffsets.empty())
+                                m_logger->info("[Worker_manager]   vOffsets: {} bytes (Prime channel)",
+                                               block_data->vOffsets.size());
 
                             auto full_block_bytes = template_interface->prepare_block_submission(
                                 block_data->merkle_root.GetBytes(),
-                                block_data->nNonce);
+                                block_data->nNonce,
+                                block_data->vOffsets);
 
                             if (full_block_bytes.empty())
                             {


### PR DESCRIPTION
Reverts NamecoinGithub/NexusMiner#521