### PR TITLE
Revert PR # 553 "Fix doom-loop race: guard degraded-mode worker re-creation while old threads are still joining"

### DIFF
--- a/src/worker_manager.cpp
+++ b/src/worker_manager.cpp
@@ -218,7 +218,7 @@ Worker_manager::Worker_manager(std::shared_ptr<asio::io_context> io_context, Con
                 size_t workers_fed = 0;
                 {
                     std::lock_guard<std::mutex> lock(self->m_worker_mutex);
-                    if (self->is_degraded() && !self->m_recovery_workers_spawned && self->m_workers.empty() && !self->m_workers_draining) {
+                    if (self->is_degraded() && !self->m_recovery_workers_spawned && self->m_workers.empty()) {
                         self->m_logger->info("[Worker_manager] Degraded mode: restarting workers before feeding recovery template");
                         self->create_workers_locked();
                         self->m_recovery_workers_spawned = !self->m_workers.empty();  // set AFTER success for exception safety
@@ -902,9 +902,7 @@ void Worker_manager::stop()
         workers_to_destroy = std::move(m_workers);
         m_workers.clear();
     }
-    m_workers_draining = true;
     workers_to_destroy.clear(); // destructors join threads here, outside the lock
-    m_workers_draining = false;
 }
 
 void Worker_manager::collect_worker_statistics(stats::Collector& collector)
@@ -1674,9 +1672,7 @@ void Worker_manager::stop_all_workers()
         // Clear the recovery gate so the next epoch can re-create workers
         m_recovery_workers_spawned = false;
     }
-    m_workers_draining = true;
     workers_to_destroy.clear(); // destructors join threads here, outside the lock
-    m_workers_draining = false;
 
     // Atomically enter WAITING_TEMPLATE so there is no window where m_workers is
     // empty while the phase is still HEALTHY.  mark_recovery_initiated() is

--- a/src/worker_manager.hpp
+++ b/src/worker_manager.hpp
@@ -228,12 +228,6 @@ private:
     // Atomic to allow concurrent access from primary and secondary SESSION_START handlers.
     std::atomic<uint16_t> m_node_keepalive_interval_hours{0};  // 0 = not yet received; fall back to config value
 
-    // Set to true while old worker threads are being joined (outside m_worker_mutex)
-    // to prevent the template distribution handler from creating new workers before
-    // old ones are fully destroyed — closing the race window introduced by the
-    // move-out-then-destroy deadlock fix (PR #539/#543).
-    std::atomic<bool> m_workers_draining{false};
-
     // Returns the best known keepalive interval: node-advertised if received, else config default.
     uint16_t get_effective_keepalive_interval() const;
 


### PR DESCRIPTION
Reverts NamecoinGithub/NexusMiner#553