### PR TITLE
Revert PR #543 "Fix deadlock in stop_all_workers(): join worker threads outside m_worker_mutex"

### DIFF
--- a/src/worker_manager.cpp
+++ b/src/worker_manager.cpp
@@ -1653,6 +1653,8 @@ void Worker_manager::clear_recovery_state()
 
 void Worker_manager::stop_all_workers()
 {
+    std::lock_guard<std::mutex> lock(m_worker_mutex);
+
     m_logger->warn("[Worker_manager] ════════════════════════════════════════");
     m_logger->warn("[Worker_manager] ⚠️  STOPPING ALL WORKERS (DEGRADED MODE)");
     m_logger->warn("[Worker_manager] ════════════════════════════════════════");
@@ -1660,19 +1662,16 @@ void Worker_manager::stop_all_workers()
     // Phase transition is handled by the caller (mark_recovery_initiated / transition_to)
     // before or after stop_all_workers() — this function is a pure physical stop.
 
-    // Move workers out under the lock, then destroy (and join their threads) OUTSIDE
-    // the lock to prevent a deadlock where a worker thread is waiting to acquire
-    // m_worker_mutex (e.g. for block submission) while stop_all_workers() holds
-    // m_worker_mutex waiting for the thread to join.
-    std::vector<std::shared_ptr<Worker>> workers_to_destroy;
-    {
-        std::lock_guard<std::mutex> lock(m_worker_mutex);
-        workers_to_destroy = std::move(m_workers);
-        m_workers.clear();
-        // Clear the recovery gate so the next epoch can re-create workers
-        m_recovery_workers_spawned = false;
+    // Reset all worker instances so that the next create_workers() call starts fresh
+    // without duplicating existing workers.  The shared_ptr reset() destroys the Worker
+    // object (and joins its mining thread in the destructor), effectively stopping it.
+    for (auto& worker : m_workers) {
+        worker.reset();
     }
-    workers_to_destroy.clear(); // destructors join threads here, outside the lock
+    m_workers.clear();
+
+    // Clear the recovery gate so the next epoch can re-create workers
+    m_recovery_workers_spawned = false;
 
     // Atomically enter WAITING_TEMPLATE so there is no window where m_workers is
     // empty while the phase is still HEALTHY.  mark_recovery_initiated() is


### PR DESCRIPTION
Reverts NamecoinGithub/NexusMiner#543