### PR TITLE
Revert PR #554 "Fix CPU prime workers permanently stuck at 0.00 GISPS"

### DIFF
--- a/src/cpu/src/cpu/worker_prime.cpp
+++ b/src/cpu/src/cpu/worker_prime.cpp
@@ -174,6 +174,7 @@ void Worker_prime::set_block(LLP::CBlock block, std::uint32_t nbits, Worker::Blo
 			// where set_block() could mutate the sieve while run() is using it.
 
 			// Signal new work is available
+			m_stop = true;
 			m_new_work = true;
 			m_running = true;
 		}
@@ -241,6 +242,7 @@ void Worker_prime::set_block(std::shared_ptr<WorkPackage> work_package, Worker::
 			// where set_block() could mutate the sieve while run() is using it.
 
 			// Signal new work is available
+			m_stop = true;
 			m_new_work = true;
 			m_running = true;
 		}


### PR DESCRIPTION
Reverts NamecoinGithub/NexusMiner#554