### PR TITLE
Revert PR #573 "Decouple GET_ROUND parity fallback from 600s timeout domain and align 480s warning-window semantics"

### DIFF
--- a/src/protocol/inc/protocol/height_tracker.hpp
+++ b/src/protocol/inc/protocol/height_tracker.hpp
@@ -330,15 +330,15 @@ public:
         }
 
         /**
-         * @brief True when template age exceeds the warning threshold (480s)
+         * @brief True when template age exceeds the warning threshold (300s)
          *
          * Proactive warning threshold to detect degraded connectivity before
-         * hitting the hard 600s timeout.
+         * hitting the hard 600s timeout. Fires after Prime block window expires.
          *
-         * @return true if template age exceeds 480 seconds
+         * @return true if template age exceeds 300 seconds
          */
         bool is_template_age_old() const {
-            constexpr uint64_t WARNING_TEMPLATE_AGE_SECONDS = 480;
+            constexpr uint64_t WARNING_TEMPLATE_AGE_SECONDS = 300;
             return get_template_age_seconds() > WARNING_TEMPLATE_AGE_SECONDS;
         }
 

--- a/src/protocol/inc/protocol/solo.hpp
+++ b/src/protocol/inc/protocol/solo.hpp
@@ -116,9 +116,9 @@ public:
     static constexpr uint32_t POLL_INTERVAL_MAX_MS = 60000;    // 60 seconds maximum
     // Minimum push-silence duration before GET_ROUND fallback may trigger GET_BLOCK.
     // Policy: while PUSH is active, GET_ROUND is informational only. Once PUSH has
-    // been silent for 480s, each GET_ROUND poll (POLL_INTERVAL_MIN_MS minimum cadence)
+    // been silent for 600s, each GET_ROUND poll (POLL_INTERVAL_MIN_MS minimum cadence)
     // may request GET_BLOCK.
-    static constexpr int64_t PUSH_ABSENT_FOR_GET_ROUND_FALLBACK_SECONDS = 480;
+    static constexpr int64_t PUSH_ABSENT_FOR_GET_ROUND_FALLBACK_SECONDS = 600;
     /// Send GET_BLOCK on all lanes (legacy: 0x81; stateless: 0xD081) to request
     /// a fresh mining template.  Authentication-guarded; delegates to get_work().
     /// Returns null/empty if not yet authenticated — callers must guard for this.
@@ -627,7 +627,7 @@ private:
     bool m_needs_initial_round_check;  // Set true when new template received
     uint32_t m_template_unified_height;    // Informational only: unified height at last template receipt (logging unified drift).
                                            // NOT used for staleness decisions (channel height is authoritative).
-    bool m_get_round_push_silent_fallback_active{false};  // Armed after PUSH silence >= 480s; cleared by new PUSH.
+    bool m_get_round_push_silent_fallback_active{false};  // Armed after PUSH silence >= 600s; cleared by new PUSH.
     
     // Helper methods for intelligent polling
     bool should_poll_get_round();

--- a/src/protocol/push_notification_lane_test.cpp
+++ b/src/protocol/push_notification_lane_test.cpp
@@ -1050,10 +1050,10 @@ int main()
     // ====================================================================
     std::cout << "\nTest 22: PUSH-silent fallback enables GET_ROUND-triggered GET_BLOCK" << std::endl;
     {
-        print_test_result("PUSH active (<480s) blocks GET_ROUND fallback trigger",
-            !should_trigger_get_round_fallback_get_block(true, 101, 101, 479));
-        print_test_result("PUSH silent (>=480s) enables GET_ROUND fallback trigger",
-            should_trigger_get_round_fallback_get_block(true, 101, 101, 480));
+        print_test_result("PUSH active (<600s) blocks GET_ROUND fallback trigger",
+            !should_trigger_get_round_fallback_get_block(true, 101, 101, 599));
+        print_test_result("PUSH silent (>=600s) enables GET_ROUND fallback trigger",
+            should_trigger_get_round_fallback_get_block(true, 101, 101, 600));
     }
 
     // ====================================================================
@@ -1073,7 +1073,7 @@ int main()
         };
         auto on_push_reestablished = [&]() { fallback_mode_armed = false; };
 
-        bool first_trigger = on_get_round_parity(480, 101, 101);
+        bool first_trigger = on_get_round_parity(600, 101, 101);
         print_test_result("Silence path first GET_ROUND parity arms fallback trigger", first_trigger && fallback_mode_armed);
 
         on_push_reestablished();

--- a/src/worker_manager.cpp
+++ b/src/worker_manager.cpp
@@ -284,7 +284,7 @@ Worker_manager::Worker_manager(std::shared_ptr<asio::io_context> io_context, Con
                             bool channel_stale = ht_snap.is_template_stale();
 
                             // Check 2 — Age (SECONDARY: safety net for missed push notifications)
-                            // 600s is the hard dead-connection gate; warning path starts at 480s.
+                            // 600s matches the push-driven era MAX_TEMPLATE_AGE
                             bool age_stale = ht_snap.is_template_age_stale();
                             uint64_t template_age = ht_snap.get_template_age_seconds();
 
@@ -401,7 +401,7 @@ Worker_manager::Worker_manager(std::shared_ptr<asio::io_context> io_context, Con
                     // Re-subscribe to push notifications if they have been silent too long.
                     // After prolonged push silence the node's push subscription may have been
                     // lost during TCP disruption or session cycling.  Sending MINER_READY
-                    // re-establishes the subscription and helps avoid entering the 480s warning window.
+                    // re-establishes the subscription and prevents the 600s timeout cycle.
                     if (solo_protocol) {
                         auto ht_snap = solo_protocol->get_height_tracker_snapshot();
                         bool push_ever_received = (ht_snap.last_push_notification_at != std::chrono::steady_clock::time_point{});


### PR DESCRIPTION
Reverts NamecoinGithub/NexusMiner#573